### PR TITLE
[Box] Fix defaultTheme injection

### DIFF
--- a/packages/material-ui/src/Box/Box.js
+++ b/packages/material-ui/src/Box/Box.js
@@ -9,8 +9,7 @@ import sizing from '@material-ui/system/sizing';
 import spacing from '@material-ui/system/spacing';
 import typography from '@material-ui/system/typography';
 import css from '@material-ui/system/css';
-import { styled } from '@material-ui/styles';
-import defaultTheme from '../styles/defaultTheme';
+import styled from '../styles/styled';
 
 export const styleFunction = css(
   compose(
@@ -29,6 +28,6 @@ export const styleFunction = css(
 /**
  * @ignore - do not document.
  */
-const Box = styled('div')(styleFunction, { name: 'MuiBox', defaultTheme });
+const Box = styled('div')(styleFunction, { name: 'MuiBox' });
 
 export default Box;

--- a/packages/material-ui/src/Box/Box.js
+++ b/packages/material-ui/src/Box/Box.js
@@ -10,6 +10,7 @@ import spacing from '@material-ui/system/spacing';
 import typography from '@material-ui/system/typography';
 import css from '@material-ui/system/css';
 import { styled } from '@material-ui/styles';
+import defaultTheme from '../styles/defaultTheme';
 
 export const styleFunction = css(
   compose(
@@ -28,6 +29,6 @@ export const styleFunction = css(
 /**
  * @ignore - do not document.
  */
-const Box = styled('div')(styleFunction, { name: 'MuiBox' });
+const Box = styled('div')(styleFunction, { name: 'MuiBox', defaultTheme });
 
 export default Box;

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { assert } from 'chai';
+import { createShallow } from '@material-ui/core/test-utils';
+import Box from './Box';
+
+describe('<Box />', () => {
+  let shallow;
+
+  before(() => {
+    shallow = createShallow({ dive: true });
+  });
+
+  const testChildren = <div className="unique">Hello World</div>;
+
+  it('renders children and box content', () => {
+    const wrapper = shallow(
+      <Box component="span" m={1}>
+        {testChildren}
+      </Box>,
+    );
+
+    assert.strictEqual(wrapper.contains(testChildren), true);
+    assert.strictEqual(wrapper.find('span').length, 1);
+  });
+});


### PR DESCRIPTION
**Description**
This PR allows using the `core/Box` component in test environments. It includes the default theme on it.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
